### PR TITLE
Update build_ignore in galaxy.yml to prevent inclusion of unnecessary files

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -54,7 +54,7 @@ issues: https://github.com/ansible-collections/Datadog/issues
 # artifact. A pattern is matched from the relative path of the file or directory of the collection directory. This
 # uses 'fnmatch' to match the files or directories. Some directories and files like 'galaxy.yml', '*.pyc', '*.retry',
 # and '.git' are always filtered. Mutually exclusive with 'manifest'
-build_ignore: []
+build_ignore: [.github, requirements.txt, tox.ini, .gitignore]
 
 # A dict controlling use of manifest directives used in building the collection artifact. The key 'directives' is a
 # list of MANIFEST.in style


### PR DESCRIPTION
##### SUMMARY

Update build_ignore in galaxy.yml to prevent inclusion of unnecessary files in the built collection archive.

##### ISSUE TYPE

- Bugfix Pull Request