### PR TITLE
Provide both links for the agent role

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,5 @@ Note for users installing the collection through the Ansible Automation Hub: Ope
 ### Collection role list
 
 - `datadog.dd.agent` : Installation and configuration of the Datadog Agent
-  - See [the official documentation of the role](https://docs.datadoghq.com/agent/guide/ansible_standalone_role/#role-variables)
-  - See [the repository of the standalone role](https://github.com/DataDog/ansible-datadog)
+  - See [the official documentation for the role](https://docs.datadoghq.com/agent/guide/ansible_standalone_role/#role-variables)
+  - See [the repository for the standalone role](https://github.com/DataDog/ansible-datadog)

--- a/README.md
+++ b/README.md
@@ -47,4 +47,6 @@ Note for users installing the collection through the Ansible Automation Hub: Ope
 
 ### Collection role list
 
-- `datadog.dd.agent` : Installation and configuration of the Datadog Agent ([full documentation](https://github.com/DataDog/ansible-datadog/blob/main/README.md))
+- `datadog.dd.agent` : Installation and configuration of the Datadog Agent
+  - See [the official documentation of the role](https://docs.datadoghq.com/agent/guide/ansible_standalone_role/#role-variables)
+  - See [the repository of the standalone role](https://github.com/DataDog/ansible-datadog)


### PR DESCRIPTION
##### SUMMARY
Provides two links for the Agent role - one for the repo and one for the docs site (this doesn't exist yet, to be merged).

##### ISSUE TYPE
- Docs Pull Request