### PR TITLE
Remove importer from ignored dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,5 +7,3 @@ updates:
       - enhancement
     schedule:
       interval: weekly
-    ignore:
-      - dependency-name: "galaxy-importer"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,3 +7,9 @@ updates:
       - enhancement
     schedule:
       interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    labels:
+      - enhancement
+    schedule:
+      interval: weekly

--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -103,7 +103,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install python3
-        run: brew install python3
+        run: brew upgrade && brew install python3
       - name: Install Ansible
         run: pip3 install ansible==${{ matrix.ansible_version}}.*
       - name: Build the Ansible collection

--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -102,8 +102,6 @@ jobs:
         ansible_version: ["2.10", "4.10"]
     steps:
       - uses: actions/checkout@v1
-      - name: Install python3
-        run: brew upgrade && brew install python3
       - name: Install Ansible
         run: pip3 install ansible==${{ matrix.ansible_version}}.*
       - name: Build the Ansible collection

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 invoke==2.2.0
-pyyaml==5.4.1
-galaxy-importer==0.4.0.post1
+galaxy-importer==0.4.14

--- a/roles/agent/meta/main.yml
+++ b/roles/agent/meta/main.yml
@@ -2,10 +2,10 @@
 galaxy_info:
   role_name: datadog
   namespace: datadog
-  author: 'Brian Akins, Dustin Brown & Datadog'
+  author: "Brian Akins, Dustin Brown & Datadog"
   description: Install Datadog agent and configure checks
   license: Apache2
-  min_ansible_version: '2.6'
+  min_ansible_version: "2.6"
   github_branch: main
   platforms:
     - name: Ubuntu
@@ -24,42 +24,42 @@ galaxy_info:
         - bullseye
     - name: EL
       versions:
-        - '6'
-        - '7'
-        - '8'
-        - '9'
-    - name: Amazon Linux
+        - "6"
+        - "7"
+        - "8"
+        - "9"
+    - name: Amazon Linux 2
       versions:
         - all
     - name: opensuse
       versions:
-        - '12.1'
-        - '12.2'
-        - '12.3'
-        - '13.1'
-        - '13.2'
-        - '42.1'
-        - '42.2'
-        - '42.3'
-        - '15.0'
-        - '15.1'
-        - '15.2'
-        - '15.3'
+        - "12.1"
+        - "12.2"
+        - "12.3"
+        - "13.1"
+        - "13.2"
+        - "42.1"
+        - "42.2"
+        - "42.3"
+        - "15.0"
+        - "15.1"
+        - "15.2"
+        - "15.3"
     - name: SLES
       versions:
         - 11SP3
         - 11SP4
-        - '12'
+        - "12"
         - 12SP1
-        - '15'
+        - "15"
     - name: Windows
       versions:
         - 2008x64
         - 2008R2
-        - '2012'
+        - "2012"
         - 2012R2
-        - '2016'
-        - '2019'
+        - "2016"
+        - "2019"
     - name: MacOSX
       versions:
         - all

--- a/test/install_agent_6.yaml
+++ b/test/install_agent_6.yaml
@@ -1,8 +1,9 @@
 ---
-
-- hosts: all
+- name: Install agent 6
+  hosts: all
   tasks:
-    - ansible.builtin.import_role:
+    - name: Import role
+      ansible.builtin.import_role:
         name: datadog.dd.agent
   vars:
     datadog_api_key: "11111111111111111111111111111111"
@@ -13,7 +14,7 @@
     datadog_config:
       tags: "mytag0, mytag1"
       log_level: INFO
-      apm_enabled: "true"  # has to be set as a string
+      apm_enabled: "true" # has to be set as a string
     datadog_config_ex:
       trace.config:
         env: dev
@@ -30,4 +31,4 @@
         init_config:
         instances:
           - name: agent
-            search_string: ['agent', 'sshd' ]
+            search_string: ["agent", "sshd"]

--- a/test/install_agent_6_macos.yaml
+++ b/test/install_agent_6_macos.yaml
@@ -1,8 +1,9 @@
 ---
-
-- hosts: all
+- name: Install agent 6 macos
+  hosts: all
   tasks:
-    - ansible.builtin.import_role:
+    - name: Import role
+      ansible.builtin.import_role:
         name: datadog.dd.agent
   vars:
     datadog_api_key: "11111111111111111111111111111111"
@@ -11,7 +12,7 @@
     datadog_config:
       tags: "mytag0, mytag1"
       log_level: INFO
-      apm_enabled: "true"  # has to be set as a string
+      apm_enabled: "true" # has to be set as a string
     datadog_config_ex:
       trace.config:
         env: dev
@@ -22,4 +23,4 @@
         init_config:
         instances:
           - name: agent
-            search_string: ['agent', 'sshd' ]
+            search_string: ["agent", "sshd"]

--- a/test/install_agent_7.yaml
+++ b/test/install_agent_7.yaml
@@ -1,8 +1,9 @@
 ---
-
-- hosts: all
+- name: Install agent 7
+  hosts: all
   tasks:
-    - ansible.builtin.import_role:
+    - name: Import role
+      ansible.builtin.import_role:
         name: datadog.dd.agent
   vars:
     datadog_api_key: "11111111111111111111111111111111"
@@ -13,7 +14,7 @@
     datadog_config:
       tags: "mytag0, mytag1"
       log_level: INFO
-      apm_enabled: "true"  # has to be set as a string
+      apm_enabled: "true" # has to be set as a string
     datadog_config_ex:
       trace.config:
         env: dev
@@ -32,4 +33,4 @@
         init_config:
         instances:
           - name: agent
-            search_string: ['agent', 'sshd' ]
+            search_string: ["agent", "sshd"]

--- a/test/install_agent_7_macos.yaml
+++ b/test/install_agent_7_macos.yaml
@@ -1,8 +1,9 @@
 ---
-
-- hosts: all
+- name: Install agent 7 macos
+  hosts: all
   tasks:
-    - ansible.builtin.import_role:
+    - name: Import role
+      ansible.builtin.import_role:
         name: datadog.dd.agent
   vars:
     datadog_api_key: "11111111111111111111111111111111"
@@ -11,7 +12,7 @@
     datadog_config:
       tags: "mytag0, mytag1"
       log_level: INFO
-      apm_enabled: "true"  # has to be set as a string
+      apm_enabled: "true" # has to be set as a string
     datadog_config_ex:
       trace.config:
         env: dev
@@ -24,4 +25,4 @@
         init_config:
         instances:
           - name: agent
-            search_string: ['agent', 'sshd' ]
+            search_string: ["agent", "sshd"]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Importer was pinned and excluded from dependabot on old version of ansible-galaxy. 
With the NG we can get rid of this constraint
- Updated galaxy importer in requirement.txt
- Removed dependabot exclusion, and took opportunity to add rule on github actions
- Fixed the new warnings raised by the linter
- Removed the `brew install python3`, as python3 is already installed and the brew formula led to [a link error](https://github.com/ansible-collections/Datadog/actions/runs/6549130971/job/17785371840). The propositions ([1](https://stackoverflow.com/questions/42454926/homebrew-cannot-link-python), [2](https://github.com/caskformula/homebrew-caskformula/issues/10#issuecomment-304886965), [3](https://github.com/Homebrew/homebrew-core/issues/20985#issuecomment-346700037)) to sort this out were not really obvious so let's use the installed python version (already 3.11)

