### PR TITLE
Update meta runtime to match Red Hat requirements and drop ansible-lint

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,18 +16,12 @@ jobs:
                 galaxy_collection_version=$(cat galaxy.yml | grep "version:" | awk -F: '{print $2}' | xargs)
                 install_info_collection_version=$(cat roles/agent/templates/install_info.j2| grep -o "datadog_collection_.*_agent_role" | awk -F_ '{ print $3 }')
                 test "$galaxy_collection_version" = "$install_info_collection_version"
-    linters:
-      uses: ansible-network/github_actions/.github/workflows/tox-linters.yml@main
     sanity:
       uses: ansible-network/github_actions/.github/workflows/sanity.yml@main
     all_green:
       needs:
-        - linters
         - sanity
       runs-on: ubuntu-latest
       steps:
-        - run: |
-            python -c "assert set([
-            '${{ needs.linters.result }}']) == {'success'}"
         - run: |
             python -c "assert '${{ needs.sanity.result }}' == 'success'"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,7 +1,7 @@
 ---
 # Collections must specify a minimum required ansible version to upload
 # to galaxy
-requires_ansible: ">=2.9.10"
+requires_ansible: ">=2.13.0"
 
 # Content that Ansible needs to load from another location or that has
 # been deprecated/removed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Update ansible minimum version to match Red Hat requirements
Remove ansible-lint since we now have the galaxy-importer call that always call ansible-lint

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
