### PR TITLE
Upgrade ansible-lint, run it separately from galaxy-importer

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,5 @@
+profile: production
+exclude_paths:
+  - .git/
+  - .github/
+  - .gitlab/

--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -1,0 +1,5 @@
+# We ignore all naming in the defaults file for the Agent role.
+# Datadog has had this role for years and having to change all variables
+# in it by adding the role prefix would break all customer setups and make
+# the transition from role to collection harder.
+roles/agent/defaults/main.yml var-naming[no-role-prefix]

--- a/.github/workflows/collection-build.yml
+++ b/.github/workflows/collection-build.yml
@@ -21,6 +21,7 @@ jobs:
           cache: 'pip'
       - name: Test importer on generated tarball
         run: |
+          export GALAXY_IMPORTER_CONFIG=./galaxy-importer.cfg
           python -m pip install -r requirements.txt
           python -m galaxy_importer.main datadog-dd-*.tar.gz 2>&1 | tee importer.log
           if grep -Eqi "(error|warning)" importer.log; then

--- a/.github/workflows/pull-ansible-role.yml
+++ b/.github/workflows/pull-ansible-role.yml
@@ -24,7 +24,8 @@ jobs:
           pip install -r requirements.txt
           ansible-galaxy collection install ansible.windows community.general
           inv role.format-fqcn
-      - name: Check ansible-datadog formating
+      - name: Run ansible-lint
         run: |
-          ansible-lint -v --profile=production --exclude=.gitlab/ --exclude=.git/ --exclude=.github/
+          pip install -r requirements-ansible-lint.txt
+          ansible-lint -v
       - uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,3 +25,10 @@ jobs:
       steps:
         - run: |
             python -c "assert '${{ needs.sanity.result }}' == 'success'"
+    ansible_lint:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Check ansible-datadog formating
+          run: |
+            pip install -r requirements-ansible-lint.txt
+            ansible-lint -v

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,6 +28,7 @@ jobs:
     ansible_lint:
       runs-on: ubuntu-latest
       steps:
+        - uses: actions/checkout@v3
         - name: Check ansible-datadog formating
           run: |
             pip install -r requirements-ansible-lint.txt

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,7 +28,7 @@ jobs:
     ansible_lint:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
         - name: Check ansible-datadog formating
           run: |
             pip install -r requirements-ansible-lint.txt

--- a/galaxy-importer.cfg
+++ b/galaxy-importer.cfg
@@ -1,0 +1,3 @@
+[galaxy-importer]
+# we will run the lint ourselves with the ansible-lint version of our choosing
+RUN_ANSIBLE_LINT = False

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,7 +1,7 @@
 ---
 # Collections must specify a minimum required ansible version to upload
 # to galaxy
-requires_ansible: ">=2.13.0"
+requires_ansible: ">=2.14.0"
 
 # Content that Ansible needs to load from another location or that has
 # been deprecated/removed

--- a/requirements-ansible-lint.txt
+++ b/requirements-ansible-lint.txt
@@ -1,0 +1,5 @@
+# ansible-lint is run by ansible-galaxy import, but sometimes there's a new
+# ansible-lint version that is required by Ansible Automation Hub, which is
+# not pulled in by even the latest ansible-galaxy. Hence we use separate set
+# of jobs to run just ansible-lint, and we can update it independently.
+ansible-lint==6.22.1

--- a/roles/agent/meta/main.yml
+++ b/roles/agent/meta/main.yml
@@ -28,9 +28,10 @@ galaxy_info:
         - '7'
         - '8'
         - '9'
-    - name: Amazon Linux 2
+    - name: Amazon Linux
       versions:
-        - all
+        - '2'
+        - '2023'
     - name: opensuse
       versions:
         - '12.1'


### PR DESCRIPTION
##### SUMMARY

Does the analogy of https://github.com/DataDog/ansible-datadog/pull/535 for this repository.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
N/A

##### ADDITIONAL INFORMATION

The Agent role's `meta/main.yml` can't be synced using the automated sync Github Action right now, as it doesn't pass the old ansible-lint, so I added it also in this change to make the sync action pass again.