### PR TITLE
Bump ansible-lint to 6.22.2 and ansible core to 2.15.0

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,7 +1,7 @@
 ---
 # Collections must specify a minimum required ansible version to upload
 # to galaxy
-requires_ansible: ">=2.14.0"
+requires_ansible: ">=2.15.0"
 
 # Content that Ansible needs to load from another location or that has
 # been deprecated/removed

--- a/requirements-ansible-lint.txt
+++ b/requirements-ansible-lint.txt
@@ -2,4 +2,4 @@
 # ansible-lint version that is required by Ansible Automation Hub, which is
 # not pulled in by even the latest ansible-galaxy. Hence we use separate set
 # of jobs to run just ansible-lint, and we can update it independently.
-ansible-lint==6.22.1
+ansible-lint==6.22.2


### PR DESCRIPTION
##### SUMMARY
PR to satisfy requirements by the February 2024 Ansible Partner Announcement:
* Bumps ansible-lint to latest 6.22.x release (6.22.2)
* Upgrades dependency on ansible core to 2.15.0.
