### PR TITLE
Sync github action isn't using a pinned ansible-lint version anymore

### DIFF
--- a/.github/workflows/pull-ansible-role.yml
+++ b/.github/workflows/pull-ansible-role.yml
@@ -26,6 +26,6 @@ jobs:
           inv role.format-fqcn
       - name: Run ansible-lint
         run: |
-          pip install -r requirements-ansible-lint.txt
+          pip install -r requirements.txt
           ansible-lint -v
       - uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION

##### SUMMARY
We should use the same ansible-lint version as the galaxy-importer's.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
