### PR TITLE
Change links to absolute links to fix 404s in public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If you need support, you can create in issue or open a support ticket to datadog
 
 ## Release Notes
 
-You can follow changes in our [CHANGELOG](CHANGELOG.rst) file
+You can follow changes in our [CHANGELOG](https://github.com/ansible-collections/Datadog/blob/main/CHANGELOG.rst) file
 
 ## Related Information
 
@@ -91,4 +91,4 @@ You can follow changes in our [CHANGELOG](CHANGELOG.rst) file
 
 ## License Information
 
-This repository is under [Apache License 2.0](LICENSE).
+This repository is under [Apache License 2.0](https://github.com/ansible-collections/Datadog/blob/main/LICENSE).


### PR DESCRIPTION
##### SUMMARY
Change some recently-added links in the README from relative to absolute. Needed to fix 404 errors in the Datadog public docs.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
