### PR TITLE
[BARX-423] Use a deploy key in the periodical sync job

### DIFF
--- a/.github/workflows/scheduled-ansible-pull.yml
+++ b/.github/workflows/scheduled-ansible-pull.yml
@@ -27,7 +27,11 @@ jobs:
     needs: check
     if: "${{ needs.check.outputs.check-output == 'true' }}"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          # Using a deploy key is required to trigger on_push workflows when pushing changes.
+          # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }} 
       - name: Empty roles/agent folder
         run: |
           rm -rf roles/agent/*
@@ -69,5 +73,7 @@ jobs:
           PR_URL=$(gh pr create --title 'Pull latest ansible-datadog version inside of the collection' --body 'Pull latest ansible-datadog version inside of the collection')
           gh pr merge $PR_URL --squash --auto
         env:
+          # The GITHUB_TOKEN is used by the `gh` CLI to create the PR.
+          # Note that it won't trigger `on: pull_request` workflows.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ID: ${{ github.run_id }}


### PR DESCRIPTION
##### SUMMARY
This PR replaces the github_token used by the sync job by an ssh-key to trigger `on_push` jobs.

The flow was tested with a similar job https://github.com/ansible-collections/Datadog/pull/61.

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

When PRs are created by the github robot, CI jobs are not triggered. This is by design https://github.com/peter-evans/create-pull-request/issues/48.

Several workarounds are documented here: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs. I would prefer using a github app but I am not sure it's doable for this repo


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
