### PR TITLE
Bump galaxy-importer and ansible-lint version 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 invoke==2.2.0
-galaxy-importer==0.4.20
+galaxy-importer==0.4.29

--- a/roles/agent/meta/main.yml
+++ b/roles/agent/meta/main.yml
@@ -28,9 +28,9 @@ galaxy_info:
         - '7'
         - '8'
         - '9'
-    - name: Amazon Linux 2
+    - name: Amazon Linux
       versions:
-        - all
+        - '2023'
     - name: opensuse
       versions:
         - '12.1'


### PR DESCRIPTION
##### SUMMARY
bumping galaxy-importer to 4.29 will also bump ansible-lint to 25.1.2

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
