### PR TITLE
Skip var-naming lint in collection

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -6,3 +6,5 @@ exclude_paths:
 warn_list:
   - var_naming
   - idiom
+skip_list:
+  - var-naming[no-role-prefix]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Resolved var-naming warnings in the ansible role, but since the `.ansible-lint` file doesn't sync across the role and collection, var-naming warnings still show when submitting the _collection_ to AAH. 
<img width="668" alt="image" src="https://github.com/user-attachments/assets/9a247e3a-5b7b-4785-beab-2f37fe1929af" />

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
