### PR TITLE
Fix scheduled ansible pull job

### DIFF
--- a/.github/workflows/collection-build.yml
+++ b/.github/workflows/collection-build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9.16'
+          python-version: '3.10'
           cache: 'pip'
       - name: Test importer on generated tarball
         run: |

--- a/.github/workflows/collection-build.yml
+++ b/.github/workflows/collection-build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           cache: 'pip'
       - name: Test importer on generated tarball
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 invoke==2.2.0
-galaxy-importer==0.4.29
+galaxy-importer==0.4.31
+# Use highest ansible-lint version supported by galaxy-importer 0.4.31
+ansible-lint==25.5.0
+ansible-core>=2.19.0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
On 7/21 `ansible-core` 2.19  was released leading to a breakage in the `scheduled ansible pull` job. This was because `ansible-core` 2.19 is incompatible with the previous version of `ansible-lint` used in the job, causing a failure. This PR updates `ansible-lint` to 25.5.0 which is compatible with `ansible-core` 2.19. A newer version of `galaxy-importer` was needed as this was the bottleneck preventing newer versions of `ansible-lint` from being installed.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
