### PR TITLE
Fix typo in requirements.yml section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Before using this collection, install it with the Ansible Galaxy command-line to
 ansible-galaxy collection install datadog.dd
 ```
 
-Alternatively, include it in a `requirements.yml` file and install it with `ansible-galaxy collection install -r requirements.yml`. Include the following in `requirments.yml`:
+Alternatively, include it in a `requirements.yml` file and install it with `ansible-galaxy collection install -r requirements.yml`. Include the following in `requirements.yml`:
 
 
 ```yaml


### PR DESCRIPTION
Fixes the spelling of the word “requirements” as used in the Ansible dependency definition file.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Ansible playbook

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Minor typo.

<!--- Paste verbatim command output below, e.g. before and after your change -->

