### PR TITLE
fix(workflow): stop scheduled sync from paging when upstream has no drift

### DIFF
--- a/.github/workflows/scheduled-ansible-pull.yml
+++ b/.github/workflows/scheduled-ansible-pull.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Check diff between roles/agent and ansible-role main branch
         id: check-diff
         run: |
-          diff -x "\.*" -x CHANGELOG.md -x CONTRIBUTING.md -x install_info.j2 -x LICENSE -x ci_test -x manual_tests -x "requirements*" -pur roles/agent/ ansible-role/ || echo "sync-needed=true" >> $GITHUB_OUTPUT
+          diff -x "\.*" -x CHANGELOG.md -x CONTRIBUTING.md -x install_info.j2 -x LICENSE -x ci_test -x manual_tests -x "requirements*" -x "*.json" -pur roles/agent/ ansible-role/ || echo "sync-needed=true" >> $GITHUB_OUTPUT
 
   execute:
     runs-on: ubuntu-latest
@@ -89,7 +89,12 @@ jobs:
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
           git checkout -b github-action/sync-$GITHUB_ID
-          git add . && git commit -m "Pull ansible-datadog"
+          git add .
+          if git diff --cached --quiet; then
+            echo "No changes to sync; exiting cleanly."
+            exit 0
+          fi
+          git commit -m "Pull ansible-datadog"
           git push --set-upstream origin github-action/sync-$GITHUB_ID
           PR_URL=$(gh pr create --title 'Pull latest ansible-datadog version inside of the collection' --body 'Pull latest ansible-datadog version inside of the collection')
           gh pr merge $PR_URL --squash --auto

--- a/.github/workflows/scheduled-ansible-pull.yml
+++ b/.github/workflows/scheduled-ansible-pull.yml
@@ -109,7 +109,7 @@ jobs:
     needs: [check, execute]
     if: "${{ always() && contains(needs.*.result, 'failure') }}"
     steps:
-      - name: Notify the workflow failure to agent-onboarding
+      - name: Notify the workflow failure to telemetry-onboarding-ops
         run: |
           payload="{\"text\":\":alert_party: The ansible-collection sync workflow failed ! Please check the following <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow error>.\"}"
           curl -X POST -H 'Content-type: application/json' --data "$payload" $SLACK_URL


### PR DESCRIPTION
The scheduled sync workflow has failed every run since 2026-03-27, paging `NOTIF_WEBHOOK_URL` daily. Cause: upstream added `renovate.json` at the repo root; the `check` job's `diff` sees it as drift, but the `execute` job's cleanup strips it before commit, so `git commit` fails on a clean tree under `bash -e`.

`.github/workflows/scheduled-ansible-pull.yml`:
1. Add `-x "*.json"` to the `check` job's `diff` — stops the false positive at the source.
2. Guard the `execute` commit step with `git diff --cached --quiet` — defensive seatbelt; exits 0 instead of failing when there's nothing to sync.
3. Rename the `fail_notification` step label from `agent-onboarding` to `telemetry-onboarding-ops` (cosmetic; real routing is the `NOTIF_WEBHOOK_URL` secret, rotated separately).
